### PR TITLE
Formatting JSON from alert definition

### DIFF
--- a/vropscli.py
+++ b/vropscli.py
@@ -186,7 +186,12 @@ class vropscli:
 
         response = requests.request("GET", url, headers=clilib.get_token_header(self.token['token']), verify=False)
         response_parsed = json.loads(response.text)
-        print("{\"alertDefinitions\": " + json.dumps(response_parsed["alertDefinitions"]) + "}")
+
+        # Creating data structure that getAlertsDefinitionByAdapterKind will like
+        responseformatted = {}
+        responseformatted["alertDefinitions"] = response_parsed["alertDefinitions"]
+
+        print(json.dumps(responseformatted, indent=2))
 
     def updateAlertDefinitions(self, alertConfigFile):
         '''->


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other review your Pull Request. -->

<!--- This template is based on github.com/zfsonlinux/zfs -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Brock, for a blog post he was writing, mentioned that the alert definitions were difficult to format.  It makes sense to format this JSON out of the box, as it's intention was to be edited by hand before import.

### Description
<!--- Describe your changes in detail -->
Format the JSON output of the `getAlertsDefinitionsByAdapterKind` subcommand.

### How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Diffed output from orginal version of getAlertsDefinitionsByAdapterKind (through jq for formatting).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code passes lint test with `pylint` (see README.md for parameters to use) 
- [N/A] I have updated the documentation.
- [N/A] I have added / updated tests to cover my changes.
- [ ] All new and existing tests passed within the Jenkinsfile
- [ ] All commit messages are clear and concise
